### PR TITLE
Converted to OpenStreetMaps

### DIFF
--- a/map.html
+++ b/map.html
@@ -4,8 +4,14 @@
     <meta charset="UTF-8">
     <title>DesertBus Community Chatmap</title>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ==" crossorigin=""/>
+    <!-- Make sure you put this AFTER Leaflet's CSS -->
+    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js" integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew==" crossorigin=""></script>
+
     <style>
-        body {
+        html, body {
+            height: 100%;
             margin: 0;
             padding: 0;
         }
@@ -13,43 +19,35 @@
         #map {
             height: 100%;
             width: 100%;
-            position: absolute;
         }
 
         #searchbar {
             width: 20em;
             position: fixed;
-            top: 4em;
-            left: 1em;
-            z-index: 1;
+            top: 1em;
+            left: 4em;
+            z-index: 500;
         }
     </style>
 
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/2.6.1/fuse.min.js"></script>
     <script type="text/javascript">
         var chatizens, searchIndex, map;
 
         function doSearch() {
-            var results = searchIndex.search($("#searchbar").val());
+            var results = searchIndex.search(document.getElementById("searchbar").value);
 
-            $("#suggestions").empty();
+            document.getElementById("suggestions").innerHTML = "";
 
-            $.each(results,
-                function (i, result) {
-                    $("#suggestions").append("<option>" + result + "</option>");
-                });
+            results.forEach(result => document.getElementById("suggestions").innerHTML += "<option>" + result + "</option>");
         }
 
         function submitSearch() {
-            $.each(chatizens,
-                function (i, chatizen) {
-                    if (chatizen.nick === $("#searchbar").val()) {
-                        map.panTo({lat: chatizen.lat, lng: chatizen.lon});
-                        map.setZoom(6);
-                    }
+            chatizens.forEach(function (chatizen) {
+                if (chatizen.nick.toUpperCase() === document.getElementById("searchbar").value.toUpperCase()) {
+                    map.setView({lat: chatizen.lat, lon: chatizen.lon}, 6);
                 }
-            );
+            });
         }
     </script>
 </head>
@@ -62,48 +60,42 @@
 <div id="map"></div>
 <script>
     function initMap() {
-        map = new google.maps.Map(document.getElementById('map'), {
-            zoom: 3,
-            center: {lat: 0, lng: 0}
+        // initialize Leaflet
+        var mainLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19, attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
         });
 
-        function addPin(i, chatizen) {
-            var marker = new google.maps.Marker({
-                position: {lat: chatizen.lat, lng: chatizen.lon},
-                map: map,
-                label: chatizen.nick[0],
-                title: chatizen.nick
-            });
+        map = L.map('map', {
+            center: {lat: 0, lon: 0},
+            zoom: 3,
+            layers: [mainLayer]
+        });
 
-            var infowindow = new google.maps.InfoWindow({
-                content: chatizen.nick
-            });
+        // show the scale bar on the lower left corner
+        L.control.scale().addTo(map);
 
-            marker.addListener('click', function () {
-                infowindow.open(map, marker);
-            });
+        function addPin(chatizen) {
+            L.marker({lat: chatizen.lat, lon: chatizen.lon}, {riseOnHover: true})
+                .bindPopup(chatizen.nick, {autoClose: false, closeOnClick: false})
+                .bindTooltip(chatizen.nick, {/*permanent: true*/}).openTooltip()
+                .addTo(map);
         }
 
         document.cookie = "password=sadmcasldkfjsdclasdkcmascdmklasdm";
-        $.getJSON(
-            "https://chatmap.dbco.link/api/chatizen",
-            function (data, status, xhr) {
-                var options = {
-                    keys: ["nick"],
-                    id: "nick"
-                };
+        fetch("https://chatmap.dbco.link/api/chatizen").then(response => response.json()).then((data) => {
+            var options = { 
+                keys: ["nick"], 
+                id: "nick" 
+            };
 
-                chatizens = data;
+            chatizens = data;
 
-                searchIndex = new Fuse(data, options);
-                $.each(data, addPin);
-            }
-        );
-
+            searchIndex = new Fuse(data, options);
+            data.forEach(chatizen => addPin(chatizen));
+        });
     }
-</script>
-<script async defer
-        src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAQ5SLYXwpkW79L0ItO2lHpiBKwFBAIRs4&callback=initMap">
+
+    initMap();
 </script>
 </body>
 </html>

--- a/map.html
+++ b/map.html
@@ -5,9 +5,15 @@
     <title>DesertBus Community Chatmap</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <!-- Leaflet -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ==" crossorigin=""/>
-    <!-- Make sure you put this AFTER Leaflet's CSS -->
     <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js" integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew==" crossorigin=""></script>
+
+    <!-- Mapbox GL (for the custom English map, which uses vector tiles) -->
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js'></script>
+    <script src="https://unpkg.com/mapbox-gl-leaflet/leaflet-mapbox-gl.js"></script>
 
     <style>
         html, body {
@@ -64,6 +70,11 @@
         var mainLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19, attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
         });
+        var EnglishLayer = L.mapboxGL({
+            attribution: '<a href="https://www.maptiler.com/copyright/" target="_blank">© MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>',
+            accessToken: 'not-needed',
+            style: 'https://api.maptiler.com/maps/4d188d87-c11b-4328-8e70-01c4cacc8c3f/style.json?key=gxTeBGYDCi08suCVsWUo'
+        });
         var GermanLayer = L.tileLayer('https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png', {
             maxZoom: 19, attribution: '&copy; <a href="https://openstreetmap.de/copyright">OpenStreetMap contributors</a>'
         });
@@ -86,6 +97,7 @@
         // show the layer control
         var baseMaps = {
             "Open Street Maps": mainLayer,
+            "English Map": EnglishLayer,
             "German OSM": GermanLayer,
             "French OSM": FrenchLayer,
             "Wikipedia": WikipediaLayer

--- a/map.html
+++ b/map.html
@@ -64,16 +64,35 @@
         var mainLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19, attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
         });
+        var GermanLayer = L.tileLayer('https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png', {
+            maxZoom: 19, attribution: '&copy; <a href="https://openstreetmap.de/copyright">OpenStreetMap contributors</a>'
+        });
+        var FrenchLayer = L.tileLayer('https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png', {
+            maxZoom: 19, attribution: '&copy; <a href="https://openstreetmap.fr/copyright">OpenStreetMap contributors</a>'
+        });
+        var WikipediaLayer = L.tileLayer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png', {
+            maxZoom: 19, attribution: '&copy; <a href="https://foundation.wikimedia.org">Wikimedia</a>'
+        });
 
         map = L.map('map', {
             center: {lat: 0, lon: 0},
             zoom: 3,
-            layers: [mainLayer]
+            layers: mainLayer
         });
 
         // show the scale bar on the lower left corner
         L.control.scale().addTo(map);
 
+        // show the layer control
+        var baseMaps = {
+            "Open Street Maps": mainLayer,
+            "German OSM": GermanLayer,
+            "French OSM": FrenchLayer,
+            "Wikipedia": WikipediaLayer
+        };
+        L.control.layers(baseMaps).addTo(map);
+
+        // Add a marker for each chatizen to the map
         function addPin(chatizen) {
             L.marker({lat: chatizen.lat, lon: chatizen.lon}, {riseOnHover: true})
                 .bindPopup(chatizen.nick, {autoClose: false, closeOnClick: false})
@@ -82,7 +101,7 @@
         }
 
         document.cookie = "password=sadmcasldkfjsdclasdkcmascdmklasdm";
-        fetch("https://chatmap.dbco.link/api/chatizen").then(response => response.json()).then((data) => {
+        fetch("/api/chatizen", {credentials: "include"}).then(response => response.json()).then((data) => {
             var options = { 
                 keys: ["nick"], 
                 id: "nick" 


### PR DESCRIPTION
Fixes #1 

Uses LeafletJS (the same library used by the main OSM website) and the OpenStreetMap tiles as a drop-in replacement for Google Maps.

For markers, I have a tooltip appear on hover, and clicking on it will open a pop-up box (that will remain until you explicitly close it). I tested having the tooltip be permanently visible, but it just looked too crowded to me - I left the option commented out on line 80, so you can give it a try if you want.

The search functionality remains, but I made the matching case-insensitive.

I also removed the JQuery library in favour of now-standard functions in JavaScript. Admittedly this is really just a personal preference thing.
